### PR TITLE
Documentation fixes / pyproject.toml update

### DIFF
--- a/classical_logic/parsing.py
+++ b/classical_logic/parsing.py
@@ -268,8 +268,7 @@ def prop(text: str, /) -> Proposition:
     Please see the prop() and props() section in the User Guide for more
     details.
 
-    Example: Example Usage
-
+    Example:
         ```python
         import classical_logic as cl
 
@@ -295,8 +294,7 @@ def props(text: str, /) -> tuple[Proposition, ...]:
     Please see the prop() and props() section in the User Guide for more
     details.
 
-    Example: Example Usage:
-
+    Example:
         ```python
         import classical_logic as cl
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,11 @@ site_author: Ederic Oytas
 theme:
   name: "material"
 
-  # Adds an option to change the pallette (light, dark)
+  features:
+    - content.code.copy  # adds a copy button for code blocks
+    - navigation.footer  # adds a footer in each page with links to the previous and next pages
+
+  # Adds an option to change the palette (light, dark)
   palette:
   
     # Palette toggle for light mode
@@ -18,7 +22,7 @@ theme:
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    
+
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,6 @@ authors = [
     {name = "Ederic", email = "Ederic <edericoytas@gmail.com>"}
 ]
 license = "MIT"
-homepage = "https://github.com/ederic-oytas/classical-logic"
-repository = "https://github.com/ederic-oytas/classical-logic"
 keywords = [
     "and",
     "biconditional",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
-[tool.poetry]
+[project]
 name = "classical-logic"
 version = "0.1.1"
 description = "Python package for propositional logic."
-authors = ["Ederic <edericoytas@gmail.com>"]
+authors = [
+    {name = "Ederic", email = "Ederic <edericoytas@gmail.com>"}
+]
 license = "MIT"
 homepage = "https://github.com/ederic-oytas/classical-logic"
 repository = "https://github.com/ederic-oytas/classical-logic"
@@ -39,6 +41,11 @@ classifiers = [
     "Typing :: Typed",
 ]
 readme = "README.md"
+
+[project.urls]
+homepage = "https://github.com/ederic-oytas/classical-logic"
+repository = "https://github.com/ederic-oytas/classical-logic"
+documentation = "https://classical-logic.readthedocs.io/en/stable/"
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
Here are the changes I made:

- Documentation
     - `mkdocs.yml`: added the code copy button feature to allow users to directly copy code examples from the documentation page
     - `mkdocs.yml`: added navigation footer feature, so there are links to the previous and next pages at the bottom of every documentation page
     - `classical_logic/parsing.py` (docstrings for functions `prop()` and `props()`): I removed the empty line before the code examples. This caused them not to render properly in the `Reference` documentation page. I also changed the "name" of these code examples to default (`Example`) to match the code example for the `Proposition` class
- `pyproject.toml`
    - According to Poetry's docs (https://python-poetry.org/docs/pyproject/#the-toolpoetry-section), most of the `[tool.poetry]` sections are deprecated, and it is recommended to put them in `[project]`. I modified `pyproject.toml` in accordance to that
    - I put the links for `homepage` and `repository` under `[project.urls]`, and I added the link to the documentation page (`documentation`)